### PR TITLE
convert BaseMessage.cs to a class not a record to allow mutability via forms. Given they are used not only on Server but on client where they can be attached to Forms classes just work better.

### DIFF
--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/Common/Common.Contracts/Base/BaseMessage.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/Common/Common.Contracts/Base/BaseMessage.cs
@@ -3,4 +3,4 @@
 /// <summary>
 /// Utlimate Base Class for Requests and Responses
 /// </summary>
-public abstract record BaseMessage { }
+public abstract class BaseMessage { }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/Common/Common.Contracts/Base/BasePagedRequest.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/Common/Common.Contracts/Base/BasePagedRequest.cs
@@ -1,6 +1,6 @@
 namespace TimeWarp.Architecture.Features;
 
-public abstract record BasePagedRequest : BaseRequest
+public abstract class BasePagedRequest : BaseRequest
 {
   public int Page { get; set; } = 1;
   public int PageSize { get; set; } = 10;

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/Common/Common.Contracts/Base/BasePagedResponse.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/Common/Common.Contracts/Base/BasePagedResponse.cs
@@ -1,10 +1,10 @@
 namespace TimeWarp.Architecture.Features;
 
-public abstract record BasePagedResponse : BaseResponse
+public abstract class BasePagedResponse : BaseResponse
 {
   public PaginationInfo Pagination { get; init; } = new();
 
-  public record PaginationInfo
+  public class PaginationInfo
   {
     [UsedImplicitly]
     public int CurrentPage { get; init; } = 1;

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/Common/Common.Contracts/Base/BaseRequest.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/Common/Common.Contracts/Base/BaseRequest.cs
@@ -4,6 +4,6 @@
 /// Base Request used for all Requests
 /// </summary>
 /// <remarks>
-/// Requests should be mutable reference types. 
+/// Requests should be mutable reference types.
 /// </remarks>
-public abstract record BaseRequest : BaseMessage { }
+public abstract class BaseRequest : BaseMessage { }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/Common/Common.Contracts/Base/BaseResponse.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/Common/Common.Contracts/Base/BaseResponse.cs
@@ -3,5 +3,5 @@
 /// <summary>
 /// Base Response used for all Requests
 /// </summary>
-public abstract record BaseResponse : BaseMessage;
+public abstract class BaseResponse : BaseMessage;
 

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Api/Api.Contracts/Features/WeatherForecast/Queries/GetWeatherForecasts.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Api/Api.Contracts/Features/WeatherForecast/Queries/GetWeatherForecasts.cs
@@ -3,7 +3,7 @@ namespace TimeWarp.Architecture.Features.WeatherForecasts;
 public static partial class GetWeatherForecasts
 {
 
-  public sealed record Query : BaseRequest, IApiRequest, IRequest<OneOf<Response, SharedProblemDetails>>
+  public sealed class Query : BaseRequest, IApiRequest, IRequest<OneOf<Response, SharedProblemDetails>>
   {
     public const string Route = "api/weatherForecasts";
 
@@ -16,7 +16,10 @@ public static partial class GetWeatherForecasts
     public string GetRoute() => $"{Route}?{nameof(Days)}={Days}";
   }
 
-  public sealed record Response(IEnumerable<WeatherForecastDto> WeatherForecasts) : BaseResponse;
+  public sealed class Response(IEnumerable<WeatherForecastDto> WeatherForecasts) : BaseResponse
+  {
+    public IEnumerable<WeatherForecastDto> WeatherForecasts { get; init; } = WeatherForecasts;
+  }
 
 
   /// <summary>
@@ -25,7 +28,7 @@ public static partial class GetWeatherForecasts
   public sealed class WeatherForecastDto
   {
     /// <summary>
-    /// The forecast for this Date 
+    /// The forecast for this Date
     /// </summary>
     /// <example>2020-06-08T12:32:39.9828696+07:00</example>
     public DateTime Date { get; set; }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/Analytics/TrackEvent.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/Analytics/TrackEvent.cs
@@ -13,7 +13,7 @@ public static partial class TrackEvent
     public string GetRoute() => $"{Route}";
   }
 
-  public record Response : BaseResponse {}
+  public class Response : BaseResponse {}
 
   //public class Validator : AbstractValidator<Command>
   //{

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/Hello/Hello.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/Hello/Hello.cs
@@ -2,7 +2,7 @@
 
 public static partial class Hello
 {
-  public sealed record Query : BaseRequest, IApiRequest, IRequest<OneOf<Response, SharedProblemDetails>>
+  public sealed class Query : BaseRequest, IApiRequest, IRequest<OneOf<Response, SharedProblemDetails>>
   {
     public const string Route = "Hello";
 
@@ -12,7 +12,7 @@ public static partial class Hello
     public string GetRoute() => $"{Route}?{nameof(Name)}={Name}";
   }
 
-  public sealed record Response : BaseResponse
+  public sealed class Response : BaseResponse
   {
     public string? Message { get; set; }
   }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/TodoItems/Commands/CreateTodoItem.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/TodoItems/Commands/CreateTodoItem.cs
@@ -18,7 +18,7 @@ public static class CreateTodoItem
     public HttpVerb GetHttpVerb() => HttpVerb.Post;
     public string GetRoute() => FormattableString.Invariant($"api/TodoItems");
   }
-  public record Response : BaseResponse { }
+  public class Response : BaseResponse { }
 
   public class Validator : AbstractValidator<Command>
   {

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/TodoItems/Commands/DeleteTodoItem.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/TodoItems/Commands/DeleteTodoItem.cs
@@ -11,7 +11,7 @@ public sealed partial class DeleteTodoItem
     public string GetRoute() => $"{Route}";
   }
 
-  public record Response : BaseResponse { }
+  public class Response : BaseResponse { }
 
   public sealed partial class Validator : AbstractValidator<Command>
   {

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/TodoItems/Commands/UpdateTodoItem.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/TodoItems/Commands/UpdateTodoItem.cs
@@ -22,7 +22,7 @@ public static class UpdateTodoItem
     public string GetRoute() => FormattableString.Invariant($"api/TodoItems/{TodoItemId:Guid}");
   }
 
-  public record Response : BaseResponse { }
+  public class Response : BaseResponse { }
 
   public class Validator : AbstractValidator<Command>
   {

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/TodoItems/TodoItemDto.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Features/TodoItems/TodoItemDto.cs
@@ -15,3 +15,15 @@ public class TodoItemDto
 
   public string Note { get; set; } = string.Empty;
 }
+
+public partial class Joe
+(
+  int? Page = null,
+  int? PageSize = null,
+  string? SearchString = null
+  )
+{
+  public int? Page { get; init; } = Page;
+  public int? PageSize { get; init; } = PageSize;
+  public string? SearchString { get; init; } = SearchString;
+}

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/CreateCommand.mixin
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/CreateCommand.mixin
@@ -7,7 +7,7 @@
 }}
 namespace {{ moxy.Class.Namespace }}
 {
-  public partial record {{$CommandName}} : BaseRequest, IRequest<{{$ResponseName}}>{};
-  public partial record {{$ResponseName}} : BaseResponse;
+  public partial class {{$CommandName}} : BaseRequest, IRequest<{{$ResponseName}}>{};
+  public partial class {{$ResponseName}} : BaseResponse;
   public partial class {{$CommandValidatorName}}: AbstractValidator<{{$CommandName}}>{};
 }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/CreateCommandMixin.md
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/CreateCommandMixin.md
@@ -15,8 +15,8 @@ public class TodoItemDto
 ```csharp
 namespace TimeWarp.Architecture.Features.TodoItems
 {
-public partial record CreateTodoItemCommand : BaseRequest, IRequest<CreateTodoItemResponse>{};
-public partial record CreateTodoItemResponse : BaseResponse;
+public partial class CreateTodoItemCommand : BaseRequest, IRequest<CreateTodoItemResponse>{};
+public partial class CreateTodoItemResponse : BaseResponse;
 public partial class CreateTodoItemCommandValidator: AbstractValidator<CreateTodoItemCommand>{};
 }
 ```

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/DeleteCommand.mixin
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/DeleteCommand.mixin
@@ -7,7 +7,7 @@
 }}
 namespace {{ moxy.Class.Namespace }}
 {
-  public partial record {{$CommandName}} : BaseRequest, IRequest<{{$ResponseName}}>{};
-  public partial record {{$ResponseName}} : BaseResponse;
+  public partial class {{$CommandName}} : BaseRequest, IRequest<{{$ResponseName}}>{};
+  public partial class {{$ResponseName}} : BaseResponse;
   public partial class {{$CommandValidatorName}}: AbstractValidator<{{$CommandName}}>{};
 }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/GetListQuery.mixin
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/GetListQuery.mixin
@@ -8,13 +8,18 @@
 #nullable enable
 namespace {{ moxy.Class.Namespace }}
 {
-  public partial record {{$QueryName}}
+  public partial class {{$QueryName}}
   (
     int? Page = null,
     int? PageSize = null,
     string? SearchString = null
-  ): BaseRequest, IRequest<{{$ResponseName}}>;
+  ): BaseRequest, IRequest<{{$ResponseName}}>
+  {
+    public int? Page { get; init; } = Page;
+    public int? PageSize { get; init; } = PageSize;
+    public string? SearchString { get; init; } = SearchString;
+  }
   
-  public partial record {{$ResponseName}} : BaseResponse;
+  public partial class {{$ResponseName}} : BaseResponse;
   public partial class {{$QueryValidatorName}}: AbstractValidator<{{$QueryName}}>{};
 }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/GetQuery.mixin
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/GetQuery.mixin
@@ -7,7 +7,7 @@
 }}
 namespace {{ moxy.Class.Namespace }}
 {
-  public partial record {{$QueryName}} : BaseRequest, IRequest<{{$ResponseName}}>{};
-  public partial record {{$ResponseName}} : BaseResponse;
+  public partial class {{$QueryName}} : BaseRequest, IRequest<{{$ResponseName}}>{};
+  public partial class {{$ResponseName}} : BaseResponse;
   public partial class {{$QueryValidatorName}}: AbstractValidator<{{$QueryName}}>{};
 }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/UpdateCommand.mixin
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Contracts/Mixins/UpdateCommand.mixin
@@ -7,7 +7,7 @@
 }}
 namespace {{ moxy.Class.Namespace }}
 {
-  public partial record {{$CommandName}} : BaseRequest, IRequest<{{$ResponseName}}>{};
-  public partial record {{$ResponseName}} : BaseResponse;
+  public partial class {{$CommandName}} : BaseRequest, IRequest<{{$ResponseName}}>{};
+  public partial class {{$ResponseName}} : BaseResponse;
   public partial class {{$CommandValidatorName}}: AbstractValidator<{{$CommandName}}>{};
 }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Application/Actions/ApplicationState.CloseModal.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Application/Actions/ApplicationState.CloseModal.cs
@@ -6,7 +6,7 @@ internal partial class ApplicationState
   public static class CloseModal
   {
     [UsedImplicitly]
-    internal record Action() : BaseAction;
+    internal class Action() : BaseAction;
 
     [UsedImplicitly]
     internal class Handler

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Application/Actions/ApplicationState.ResetStore.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Application/Actions/ApplicationState.ResetStore.cs
@@ -7,20 +7,15 @@ internal partial class ApplicationState
   public static class ResetStore
   {
 
-    internal record Action : BaseAction { }
+    internal class Action : BaseAction { }
 
-    internal class Handler : IRequestHandler<Action>
+    [UsedImplicitly]
+    internal class Handler
+    (
+      IStore Store,
+      ISender Sender
+    ) : IRequestHandler<Action>
     {
-      private readonly ISender Sender;
-
-      private readonly IStore Store;
-
-      public Handler(IStore store, ISender sender)
-      {
-        Sender = sender;
-        Store = store;
-      }
-
       public async Task Handle(Action action, CancellationToken cancellationToken)
       {
         Store.Reset();

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Application/Actions/ApplicationState.SetActiveModal.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Application/Actions/ApplicationState.SetActiveModal.cs
@@ -4,7 +4,10 @@ internal partial class ApplicationState
 {
   public static class SetActiveModal
   {
-    internal record Action(string ModalId) : BaseAction;
+    internal class Action(string ModalId) : BaseAction
+    {
+      public string ModalId { get; set; } = ModalId;
+    }
 
     [UsedImplicitly]
     internal class Handler

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Application/Actions/ApplicationState.ToggleMenu.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Application/Actions/ApplicationState.ToggleMenu.cs
@@ -4,10 +4,14 @@ internal partial class ApplicationState
 {
   public static class ToggleMenu
   {
-    internal record Action : BaseAction { }
-    internal class Handler : BaseHandler<Action>
+    internal class Action : BaseAction { }
+
+    [UsedImplicitly]
+    internal class Handler
+    (
+      IStore store
+    ) : BaseHandler<Action>(store)
     {
-      public Handler(IStore store) : base(store) { }
 
       public override Task Handle(Action action, CancellationToken cancellationToken)
       {

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Base/BaseAction.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Base/BaseAction.cs
@@ -1,3 +1,3 @@
 namespace TimeWarp.Architecture.Features;
 
-public abstract record BaseAction : BaseRequest, IAction;
+public abstract class BaseAction : BaseRequest, IAction;

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Chat/Actions/ChatState.ClientToServerMessageAction.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Chat/Actions/ChatState.ClientToServerMessageAction.cs
@@ -5,16 +5,19 @@ public sealed partial class ChatState
   public static class ClientToServerMessage
   {
     [TrackAction]
-    public record Action(SendMessage.Command SendMessageCommand) : BaseAction;
-
-    internal sealed class Handler : BaseHandler<Action>
+    public class Action(SendMessage.Command SendMessageCommand) : BaseAction
     {
-      private ChatHubConnection ChatHubConnection { get; set; }
+      public SendMessage.Command SendMessageCommand { get; set; } = SendMessageCommand;
+    }
 
-      public Handler(IStore store, ChatHubConnection chatHubConnection) : base(store)
-      {
-        ChatHubConnection = chatHubConnection;
-      }
+    [UsedImplicitly]
+    internal sealed class Handler
+    (
+      IStore store,
+      ChatHubConnection chatHubConnection
+    ) : BaseHandler<Action>(store)
+    {
+      private ChatHubConnection ChatHubConnection { get; set; } = chatHubConnection;
 
       public override async Task Handle(Action action, CancellationToken cancellationToken)
       {

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Chat/Actions/ChatState.ServerToClientMessageAction.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Chat/Actions/ChatState.ServerToClientMessageAction.cs
@@ -5,8 +5,12 @@ public sealed partial class ChatState
   public static class ServerToClientMessage
   {
     [TrackAction]
-    public record Action(ReceiveMessage.Command Command) : BaseAction { }
+    public class Action(ReceiveMessage.Command Command) : BaseAction
+    {
+      public ReceiveMessage.Command Command { get; set; } = Command;
+    }
 
+    [UsedImplicitly]
     internal sealed class Handler
     (
       IStore store

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Counter/Actions/CounterState.IncrementCounter.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Counter/Actions/CounterState.IncrementCounter.cs
@@ -4,7 +4,10 @@ internal partial class CounterState
 {
   public static class IncrementCounter
   {
-    public record Action(int Amount) : BaseAction;
+    public class Action(int Amount) : BaseAction
+    {
+      public int Amount { get; set; } = Amount;
+    }
 
     [UsedImplicitly]
     internal class Handler

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Counter/Actions/CounterState.ThrowException.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Counter/Actions/CounterState.ThrowException.cs
@@ -4,10 +4,17 @@ internal partial class CounterState
 {
   public static class ThrowException
   {
-    public record Action(string Message) : BaseAction;
-    internal class Handler : BaseHandler<Action>
+    public class Action(string Message) : BaseAction
     {
-      public Handler(IStore store) : base(store) { }
+      public string Message { get; init; } = Message;
+    }
+
+    [UsedImplicitly]
+    internal class Handler
+    (
+      IStore store
+    ) : BaseHandler<Action>(store)
+    {
 
       public override Task Handle
       (

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/EventStream/Actions/EventStreamState.AddEvent.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/EventStream/Actions/EventStreamState.AddEvent.cs
@@ -5,13 +5,13 @@ internal partial class EventStreamState
   public static class AddEvent
   {
 
-    internal record Action : BaseAction
+    internal sealed class Action : BaseAction
     {
       public required string Message { get; init; }
     }
 
     [UsedImplicitly]
-    internal class Handler
+    internal sealed class Handler
     (
       IStore store
     ) : BaseHandler<Action>(store)
@@ -23,7 +23,7 @@ internal partial class EventStreamState
         CancellationToken aCancellationToken
       )
       {
-        EventStreamState._Events.Add(action.Message);
+        EventStreamState.EventList.Add(action.Message);
         return Task.CompletedTask;
       }
     }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/EventStream/EventStreamState.Debug.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/EventStream/EventStreamState.Debug.cs
@@ -1,6 +1,6 @@
 namespace TimeWarp.Architecture.Features.EventStreams;
 
-internal partial class EventStreamState : State<EventStreamState>
+internal partial class EventStreamState
 {
   /// <summary>
   /// Use in Tests ONLY, to initialize the State
@@ -9,6 +9,6 @@ internal partial class EventStreamState : State<EventStreamState>
   public void Initialize(List<string> aEvents)
   {
     ThrowIfNotTestAssembly(Assembly.GetCallingAssembly());
-    _Events = aEvents;
+    EventList = aEvents;
   }
 }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/EventStream/EventStreamState.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/EventStream/EventStreamState.cs
@@ -1,16 +1,11 @@
 namespace TimeWarp.Architecture.Features.EventStreams;
 
 [StateAccessMixin]
-internal partial class EventStreamState : State<EventStreamState>
+internal sealed partial class EventStreamState : State<EventStreamState>
 {
-  private List<string> _Events { get; set; }
+  private List<string> EventList { get; set; } = [];
 
-  public IReadOnlyList<string> Events => _Events.AsReadOnly();
-
-  public EventStreamState()
-  {
-    _Events = new List<string>();
-  }
+  public IReadOnlyList<string> Events => EventList.AsReadOnly();
 
   public override void Initialize() { }
 }

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Notification/Actions/NotificationState.AddNotification.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Notification/Actions/NotificationState.AddNotification.cs
@@ -2,22 +2,27 @@
 
 using static NotificationState.Notification;
 
-internal partial class NotificationState
+internal sealed partial class NotificationState
 {
   [UsedImplicitly]
   public static class AddNotification
   {
 
     [UsedImplicitly]
-    internal record Action
+    internal sealed class Action
     (
       string Title,
       string Message,
       NotificationType Type
-    ) : BaseAction;
+    ) : BaseAction
+    {
+      public string Title { get; set; } = Title;
+      public string Message { get; set; } = Message;
+      public NotificationType Type { get; set; } = Type;
+    }
 
     [UsedImplicitly]
-    internal class Handler
+    internal sealed class Handler
     (
       IStore store
     ) : BaseHandler<Action>(store)

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Notification/Actions/NotificationState.AddProblemDetails.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Notification/Actions/NotificationState.AddProblemDetails.cs
@@ -9,13 +9,16 @@ internal partial class NotificationState
   {
 
     [UsedImplicitly]
-    internal record Action
+    internal sealed class Action
     (
       SharedProblemDetails SharedProblemDetails
-    ) : BaseAction;
+    ) : BaseAction
+    {
+      public SharedProblemDetails SharedProblemDetails { get; init; } = SharedProblemDetails;
+    }
 
     [UsedImplicitly]
-    internal class Handler
+    internal sealed class Handler
     (
       IStore store
     ) : BaseHandler<Action>(store)

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/ProfileMenu/Actions/ProfileMenuState.Close.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/ProfileMenu/Actions/ProfileMenuState.Close.cs
@@ -4,11 +4,14 @@ internal partial class ProfileMenuState
 {
   public static class Close
   {
-    internal record Action : BaseAction { }
-    internal class Handler : BaseHandler<Action>
-    {
-      public Handler(IStore store) : base(store) { }
+    internal class Action : BaseAction { }
 
+    [UsedImplicitly]
+    internal class Handler
+    (
+      IStore store
+    ) : BaseHandler<Action>(store)
+    {
       public override Task Handle(Action action, CancellationToken cancellationToken)
       {
         if (ProfileMenuState.MenuState == MenuStates.Open)

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/ProfileMenu/Actions/ProfileMenuState.Toggle.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/ProfileMenu/Actions/ProfileMenuState.Toggle.cs
@@ -4,7 +4,7 @@ internal partial class ProfileMenuState
 {
   public static class Toggle
   {
-    internal record Action : BaseAction { }
+    internal class Action : BaseAction { }
 
     [UsedImplicitly]
     internal class Handler

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Sidebar/Actions/SidebarState.CloseSideBar.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Sidebar/Actions/SidebarState.CloseSideBar.cs
@@ -4,11 +4,14 @@ internal partial class SidebarState
 {
   public static class CloseSideBar
   {
-    internal record Action : BaseAction { }
-    internal class Handler : BaseHandler<Action>
-    {
-      public Handler(IStore store) : base(store) { }
+    internal class Action : BaseAction { }
 
+    [UsedImplicitly]
+    internal class Handler
+    (
+      IStore store
+    ) : BaseHandler<Action>(store)
+    {
       public override Task Handle(Action action, CancellationToken cancellationToken)
       {
         SidebarState.IsOpen = false;

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Sidebar/Actions/SidebarState.OpenSideBar.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Sidebar/Actions/SidebarState.OpenSideBar.cs
@@ -4,11 +4,14 @@ internal partial class SidebarState
 {
   public static class OpenSideBar
   {
-    internal record Action : BaseAction { }
-    internal class Handler : BaseHandler<Action>
-    {
-      public Handler(IStore store) : base(store) { }
+    internal class Action : BaseAction { }
 
+    [UsedImplicitly]
+    internal class Handler
+    (
+      IStore store
+    ) : BaseHandler<Action>(store)
+    {
       public override Task Handle(Action action, CancellationToken cancellationToken)
       {
         SidebarState.IsOpen = true;

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Superhero/Actions/FetchSuperhero/SuperheroState.FetchSuperhero.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/Superhero/Actions/FetchSuperhero/SuperheroState.FetchSuperhero.cs
@@ -1,19 +1,18 @@
 ﻿namespace TimeWarp.Architecture.Features.Superheros;
+
 internal partial class SuperheroState
 {
   public static class FetchSuperhero
   {
-
-    public record Action : BaseAction { }
+    public sealed class Action : BaseAction { }
 
     [UsedImplicitly]
-    public class Handler
+    public sealed class Handler
     (
       IStore store,
       ISuperheroService superheroService
     ) : BaseHandler<Action>(store)
     {
-
       public override async Task Handle(Action action, CancellationToken aCancellationToken)
       {
         SuperheroState.SuperheroList.Clear();

--- a/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/WeatherForecast/Actions/WeatherForecastState.FetchWeatherForecasts.cs
+++ b/Source/TimeWarp.Architecture.Template/templates/TimeWarp.Architecture/Source/ContainerApps/Web/Web.Spa/Features/WeatherForecast/Actions/WeatherForecastState.FetchWeatherForecasts.cs
@@ -5,10 +5,13 @@ internal partial class WeatherForecastsState
   public static class FetchWeatherForecasts
   {
     [TrackAction]
-    internal sealed record Action
+    internal sealed class Action
     (
       int? Days
-    ) : BaseAction;
+    ) : BaseAction
+    {
+      public int? Days { get; init; } = Days;
+    }
 
     [UsedImplicitly]
     internal class Handler


### PR DESCRIPTION
…a forms.

Given they are used not only on Server but on client where they can be attached to Forms classes just work better.