### PR TITLE
Update .NET SDK version to 9.0.300 and add SDK setup step

### DIFF
--- a/.github/workflows/timewarp-architecture.yml
+++ b/.github/workflows/timewarp-architecture.yml
@@ -26,8 +26,11 @@ jobs:
           ls ${{ github.workspace }}
       - run: echo "🍏 This job's status is ${{ job.status }}."
 
-      - name: List Installed .NET SDKs
-        run: dotnet --list-sdks
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
 
       - name: Pack
         run: |


### PR DESCRIPTION
Updated .NET SDK version to 9.0.300 in global.json files, removed allowPrerelease, and added a setup step for .NET SDK 9.0.x in the workflow.