### PR TITLE
Update TimeWarp.Architecture template version to 2.0.0-alpha.11+9.0.300

### DIFF
--- a/TimeWarp.Templates/Source/TimeWarp.Architecture.Template/TimeWarp.Architecture.csproj
+++ b/TimeWarp.Templates/Source/TimeWarp.Architecture.Template/TimeWarp.Architecture.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageType>Template</PackageType>
     <PackageId>TimeWarp.Architecture</PackageId>
-    <Version>2.0.0-alpha.10+8.0.200</Version>
+    <Version>2.0.0-alpha.11+9.0.300</Version>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
     <Title>TimeWarp Architecture</Title>
     <Authors>Steven T. Cramer</Authors>


### PR DESCRIPTION
This PR updates the version of the TimeWarp.Architecture template to 2.0.0-alpha.11+9.0.300.