### PR TITLE
build: bump version and platform pins to 2.0.0-beta.15

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,28 +20,28 @@
          itself uses project refs). Per task-124 policy, these pins equal the release <Version> and
          bump in the same commit as it — packages and template publish together in one release run,
          so pins always reference versions that exist by the time a generated app restores. -->
-    <PackageVersion Include="TimeWarp.Foundation.Domain" Version="2.0.0-beta.14" />
-    <PackageVersion Include="TimeWarp.Foundation.Contracts" Version="2.0.0-beta.14" />
-    <PackageVersion Include="TimeWarp.Foundation.Application" Version="2.0.0-beta.14" />
-    <PackageVersion Include="TimeWarp.Foundation.Infrastructure" Version="2.0.0-beta.14" />
-    <PackageVersion Include="TimeWarp.Foundation.Server" Version="2.0.0-beta.14" />
-    <PackageVersion Include="TimeWarp.Modules" Version="2.0.0-beta.14" />
+    <PackageVersion Include="TimeWarp.Foundation.Domain" Version="2.0.0-beta.15" />
+    <PackageVersion Include="TimeWarp.Foundation.Contracts" Version="2.0.0-beta.15" />
+    <PackageVersion Include="TimeWarp.Foundation.Application" Version="2.0.0-beta.15" />
+    <PackageVersion Include="TimeWarp.Foundation.Infrastructure" Version="2.0.0-beta.15" />
+    <PackageVersion Include="TimeWarp.Foundation.Server" Version="2.0.0-beta.15" />
+    <PackageVersion Include="TimeWarp.Modules" Version="2.0.0-beta.15" />
     <!-- Analyzer/generator packages (task 092). Package IDs composed via properties so template
          sourceName cannot rewrite them (task 115). Per task-124 policy, these pins equal the
          release <Version> and bump in the same commit as it. -->
-    <PackageVersion Include="$(TwArchitectureAnalyzersPackageId)" Version="2.0.0-beta.14" />
-    <PackageVersion Include="$(TwArchitectureGeneratorsPackageId)" Version="2.0.0-beta.14" />
-    <PackageVersion Include="$(TwArchitectureAttributesPackageId)" Version="2.0.0-beta.14" />
+    <PackageVersion Include="$(TwArchitectureAnalyzersPackageId)" Version="2.0.0-beta.15" />
+    <PackageVersion Include="$(TwArchitectureGeneratorsPackageId)" Version="2.0.0-beta.15" />
+    <PackageVersion Include="$(TwArchitectureAttributesPackageId)" Version="2.0.0-beta.15" />
     <!-- TimeWarp.Identity has been published since 2.0.0-beta.6 (task 124). Per task-124 policy,
          this pin equals the release <Version> and bumps in the same commit as it, same as the
          TimeWarp.Foundation.* and analyzer/generator pins above. This pin is inert for this
          repo/CI (UseIdentityPackages resolves to ProjectReference mode when identity source is
          present) and only matters for package-mode consumers (generated apps always package-mode). -->
-    <PackageVersion Include="TimeWarp.Identity" Version="2.0.0-beta.14" />
+    <PackageVersion Include="TimeWarp.Identity" Version="2.0.0-beta.15" />
     <!-- TimeWarp.402: packed by the release run (workflow-command.cs) and template-smoke's local
          feed; first nuget.org publish rides the next release. Same task-124 pin policy as
          TimeWarp.Identity above — equals <Version>, bumps in the same commit (task 104-035). -->
-    <PackageVersion Include="TimeWarp.402" Version="2.0.0-beta.14" />
+    <PackageVersion Include="TimeWarp.402" Version="2.0.0-beta.15" />
     <PackageVersion Include="TimeWarp.Multiavatar" Version="1.0.0-beta.13" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions Packages">

--- a/kanban/in-progress/178-bump-version-to-200-beta15-for-release-first-timewarp402-nugetorg-ship.md
+++ b/kanban/in-progress/178-bump-version-to-200-beta15-for-release-first-timewarp402-nugetorg-ship.md
@@ -13,7 +13,7 @@ This bump is the release PR for shipping current master, including the first nug
 
 - [x] Bump `<Version>` in `source/Directory.Build.props` and `timewarp-templates/Directory.Build.props`
 - [x] Bump all platform CPM pins in `Directory.Packages.props` to the same version (task 124)
-- [ ] `dev check-version` reports source ahead of latest published/tag
+- [x] `dev check-version` reports source ahead of latest published/tag
 - [ ] PR green; merge to master
 - [ ] Master CI green; cut with `dev release` from clean synced master
 

--- a/kanban/in-progress/178-bump-version-to-200-beta15-for-release-first-timewarp402-nugetorg-ship.md
+++ b/kanban/in-progress/178-bump-version-to-200-beta15-for-release-first-timewarp402-nugetorg-ship.md
@@ -1,0 +1,23 @@
+# Bump version to 2.0.0-beta.15 for release (first TimeWarp.402 nuget.org ship)
+
+## Description
+
+`2.0.0-beta.14` is already tagged and partially published (10/11 platform packages; **TimeWarp.402
+did not exist** at the tag commit). Master has moved on (PR #298 + earlier work). Per `/tw-release`,
+do **not** re-tag beta.14 — bump and cut a new release.
+
+This bump is the release PR for shipping current master, including the first nuget.org publish of
+`TimeWarp.402`.
+
+## Checklist
+
+- [x] Bump `<Version>` in `source/Directory.Build.props` and `timewarp-templates/Directory.Build.props`
+- [x] Bump all platform CPM pins in `Directory.Packages.props` to the same version (task 124)
+- [ ] `dev check-version` reports source ahead of latest published/tag
+- [ ] PR green; merge to master
+- [ ] Master CI green; cut with `dev release` from clean synced master
+
+## Session
+
+- Created after PR #298 merge: beta.14 tag at `a0f092d4`; master at `09c4f7d8`; check-version
+  warned partial publish Missing TimeWarp.402 (new package, not a failed beta.14 push).

--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -11,7 +11,7 @@
     <!-- Single repo-wide package version. Lives here (not root) so it matches the TimeWarp convention
          and `dev check-version`, which read source/Directory.Build.props. Keep in sync with the
          timewarp-templates tree's <Version> — both publish at this version. -->
-    <Version>2.0.0-beta.14</Version>
+    <Version>2.0.0-beta.15</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-architecture</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/timewarp-templates/Directory.Build.props
+++ b/timewarp-templates/Directory.Build.props
@@ -4,7 +4,7 @@
        so the package version is set here directly. Keep in sync with the root Directory.Build.props
        <Version> — both publish at the single repo-wide version. -->
   <PropertyGroup>
-    <Version>2.0.0-beta.14</Version>
+    <Version>2.0.0-beta.15</Version>
     <Authors>Steven T. Cramer</Authors>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Bump repo `<Version>` to **2.0.0-beta.15** (`source/Directory.Build.props` + `timewarp-templates/Directory.Build.props`).
- Bump all platform CPM pins to the same version (task 124): Foundation.*, Modules, Architecture Analyzers/Generators/Attributes, Identity, **TimeWarp.402**.
- Kanban **178**.

`2.0.0-beta.14` is already tagged/published; TimeWarp.402 was added after that tag and cannot ship as beta.14. First nuget.org publish of TimeWarp.402 rides this release after merge + `dev release`.

## Test plan
- [x] `ganda repo audit` — 24/0
- [x] `dev check-version` — source 2.0.0-beta.15 > NuGet 2.0.0-beta.14, safe to release
- [ ] CI green on this PR
- [ ] After merge: master CI green, then `dev release` from clean synced master