### PR TITLE
fix(githooks): silence GlobalUsingsAnalyzer on post-merge/post-commit

### DIFF
--- a/.githooks/Directory.Build.props
+++ b/.githooks/Directory.Build.props
@@ -1,0 +1,13 @@
+<Project>
+  <!-- Shebang git hooks are single-file apps with no project global-usings.cs. Repo-root
+       TreatWarningsAsErrors + GlobalUsingsAnalyzer (task 172) turn a file-level using into a
+       scary "build failed" on every commit/merge even though the hook exits 0. Disable style
+       analyzers for this tree only; hooks stay tiny FQ-call scripts. -->
+  <PropertyGroup>
+    <RunAnalyzers>false</RunAnalyzers>
+    <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <AnalysisLevel>none</AnalysisLevel>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/kanban/in-progress/179-silence-globalusingsanalyzer-on-shebang-git-hooks-post-mergepost-commit.md
+++ b/kanban/in-progress/179-silence-globalusingsanalyzer-on-shebang-git-hooks-post-mergepost-commit.md
@@ -1,0 +1,25 @@
+# Silence GlobalUsingsAnalyzer on shebang git hooks (post-merge/post-commit)
+
+## Description
+
+After task 172 restored **GlobalUsingsAnalyzer** repo-wide (TreatWarningsAsErrors), the
+`.githooks/post-merge` and `post-commit` shebang runfiles print:
+
+```text
+error GlobalUsingsAnalyzer: Move using TimeWarp.Amuru to global-usings.cs
+The build failed. Fix the build errors and run again.
+```
+
+on every merge/commit. Hooks still exit 0 (pull succeeds), but the noise looks like a failed
+pull. Single-file hooks have no project `global-usings.cs`, so the analyzer is a false positive.
+
+## Checklist
+
+- [x] `.githooks/Directory.Build.props` disables analyzers / TreatWarningsAsErrors for this tree
+- [x] `post-merge` / `post-commit` run clean (memsearch index starts, no GlobalUsingsAnalyzer)
+- [ ] PR green; merge
+
+## Session
+
+- Repro: `git pull` on master after #299; hook path `.githooks/post-merge(6,1)`.
+- Fix: tree-local Directory.Build.props (`RunAnalyzers=false`, `AnalysisLevel=none`, …).


### PR DESCRIPTION
## Summary
- After task 172 restored GlobalUsingsAnalyzer, shebang hooks under `.githooks/` print a scary **build failed** / *Move using TimeWarp.Amuru to global-usings.cs* on every `git pull` / commit.
- Hooks still exit 0 (pull succeeds); single-file scripts have no project `global-usings.cs`.
- Add `.githooks/Directory.Build.props` to turn off analyzers / TreatWarningsAsErrors for that tree only.
- Kanban **179**.

## Test plan
- [x] `.githooks/post-merge` → `Started background memsearch index`, no GlobalUsingsAnalyzer
- [x] `.githooks/post-commit` same
- [ ] CI green