### PR TITLE
docs(skills): add tw-blazor razor file-order convention

### DIFF
--- a/kanban/done/190-add-tw-blazor-skill-for-razor-file-order.md
+++ b/kanban/done/190-add-tw-blazor-skill-for-razor-file-order.md
@@ -1,0 +1,44 @@
+# Add tw-blazor skill for razor file order
+
+## Description
+
+Capture the `.razor` file-order convention (one `@code` at the top, markup, optional
+`<style>` last) as `skills/tw-blazor`, sibling to `tw-blazor-css-strategy` and
+`tw-blazor-layout`. Register it as a ganda skill source.
+
+## Checklist
+
+- [x] Write `skills/tw-blazor/SKILL.md`
+- [x] `ganda skills add` + `ganda skills sync`
+- [x] Commit
+
+## Notes
+
+Source URI uses this `dev` worktree until the skill is on `master`
+(siblings already point at `master`).
+
+## Results
+
+`skills/tw-blazor/SKILL.md` is the SSOT. Registered and synced:
+
+```text
+ganda skills add tw-blazor worktree://github.com/TimeWarpEngineering/timewarp-architecture/dev/skills/tw-blazor
+ganda skills sync
+```
+
+### How to validate
+
+```bash
+ganda skills list
+# Expect: tw-blazor → worktree://…/timewarp-architecture/dev/skills/tw-blazor
+
+test -f skills/tw-blazor/SKILL.md && echo ok
+# Expect: ok
+
+rg -n "Never two \`@code\`" skills/tw-blazor/SKILL.md
+# Expect: one match
+```
+
+## Session
+
+- Implementation: grok 2026-08-13

--- a/skills/tw-blazor/SKILL.md
+++ b/skills/tw-blazor/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: tw-blazor
+description: >-
+  Razor file authoring — one @code at the top, markup, optional <style> last.
+  Use when creating or editing .razor files, @code blocks, or in-file <style>
+  tags. CSS placement: tw-blazor-css-strategy. App shell: tw-blazor-layout.
+---
+
+# `.razor` file order
+
+1. Directives (`@namespace`, `@inherits`, `@using`, `@inject`, comments)
+2. **One** `@code { … }` — omit if none or code-behind only
+3. Markup
+4. Optional `<style>` last (Exception B — `tw-blazor-css-strategy`)
+
+Never two `@code` blocks. Never `@code` after markup. Never `<style>` above markup.
+
+```razor
+@namespace TimeWarp.Architecture.Features.Example
+@inherits BaseComponent
+
+@code {
+  [Parameter] public string? Title { get; set; }
+}
+
+<div class="twe-example">@Title</div>
+
+<style>
+  @(@"
+    .twe-example { color: var(--twe-ink); }
+  ")
+</style>
+```


### PR DESCRIPTION
## Summary
- Add `skills/tw-blazor` for the house `.razor` file order: one `@code` at the top, markup, optional `<style>` last.
- Sibling of `tw-blazor-css-strategy` and `tw-blazor-layout`. Task 190.
- After merge, install from the catalog:

```bash
ganda skills add TimeWarpEngineering/timewarp-architecture --skill tw-blazor
ganda skills sync
```

## Test plan
- [x] `ganda repo audit` (24/0)
- [ ] Skill-only change — no `dev build`
- [ ] After merge: skill appears under `ganda skills add TimeWarpEngineering/timewarp-architecture --list` and on https://timewarp.software/llms.txt after the site rebuild