### PR TITLE
fix(skills): single-line descriptions for the software catalog

### DIFF
--- a/kanban/done/193-flatten-skill-yaml-descriptions-so-the-site-catalog-parses-them.md
+++ b/kanban/done/193-flatten-skill-yaml-descriptions-so-the-site-catalog-parses-them.md
@@ -1,0 +1,42 @@
+# Flatten skill YAML descriptions so the site catalog parses them
+
+## Description
+
+timewarp.software QA: six architecture skills published with raw `>-` / `>` as
+the description. The live site generator (software `master`) reads only the
+first line after `description:`. Folded YAML scalars therefore become a
+blockquote/empty callout on the catalog and skill pages.
+
+## Requirements
+
+- Single-line `description` (and `when-to-use`) on the six broken skills
+- No `description: >` / `>-` left under `skills/**/SKILL.md`
+
+## Checklist
+
+- [x] Flatten tw-aggregate-pattern, tw-blazor, tw-feature-placement,
+      tw-mock-response-factory, tw-slice-isolation, tw-web-api-contracts
+- [x] Commit
+
+## Results
+
+All six skill frontmatters are single-line. A naive first-line parser will
+publish the real description. Software `master` still needs the block-scalar
+parser (separate PR) so future folded YAML stays safe.
+
+### How to validate
+
+```bash
+rg -n '^description: *>' skills --glob 'SKILL.md'
+# Expect: no matches
+
+rg -n '^when-to-use: *>' skills --glob 'SKILL.md'
+# Expect: no matches
+```
+
+After merge + site rebuild: https://timewarp.software/skills/index.json
+descriptions for those six names are sentences, not `>-` / `>`.
+
+## Session
+
+- Implementation: grok 2026-08-13

--- a/skills/tw-aggregate-pattern/SKILL.md
+++ b/skills/tw-aggregate-pattern/SKILL.md
@@ -1,16 +1,7 @@
 ---
 name: tw-aggregate-pattern
-description: >-
-  **TIMEWARP SKILL** — the golden aggregate-root pattern: typed id, `Entity<TId>` base,
-  fail-closed `Create`, named mutations with no public setters, a private nested `Invariants`
-  validator, and save-time enforcement via `DomainInvariantsGuard`/`AggregateDbContext`. Invoke
-  before adding or reviewing an `IAggregateRoot`, or when TWA0011/TWA0012 fire.
-  WHEN: "add an aggregate", "IAggregateRoot", "aggregate root", "TWA0011", "TWA0012",
-  "Invariants validator", "typed id".
-when-to-use: >
-  aggregate root, IAggregateRoot, Entity<TId>, typed id, TypedId, Invariants validator,
-  DomainInvariantsGuard, AggregateDbContext, TWA0011, TWA0012, fail-closed construction,
-  named mutation, concurrency token, Version
+description: "**TIMEWARP SKILL** — the golden aggregate-root pattern: typed id, `Entity<TId>` base, fail-closed `Create`, named mutations with no public setters, a private nested `Invariants` validator, and save-time enforcement via `DomainInvariantsGuard`/`AggregateDbContext`. Invoke before adding or reviewing an `IAggregateRoot`, or when TWA0011/TWA0012 fire. WHEN: add an aggregate, IAggregateRoot, aggregate root, TWA0011, TWA0012, Invariants validator, typed id."
+when-to-use: aggregate root, IAggregateRoot, Entity<TId>, typed id, TypedId, Invariants validator, DomainInvariantsGuard, AggregateDbContext, TWA0011, TWA0012, fail-closed construction, named mutation, concurrency token, Version
 ---
 
 # Aggregate pattern (TWA0011/0012)

--- a/skills/tw-blazor/SKILL.md
+++ b/skills/tw-blazor/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: tw-blazor
-description: >-
-  Razor file authoring — one @code at the top, markup, optional <style> last.
-  Use when creating or editing .razor files, @code blocks, or in-file <style>
-  tags. CSS placement: tw-blazor-css-strategy. App shell: tw-blazor-layout.
+description: Razor file authoring — one @code at the top, markup, optional <style> last. Use when creating or editing .razor files, @code blocks, or in-file <style> tags. CSS placement: tw-blazor-css-strategy. App shell: tw-blazor-layout.
 ---
 
 # `.razor` file order

--- a/skills/tw-blazor/SKILL.md
+++ b/skills/tw-blazor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tw-blazor
-description: Razor file authoring — one @code at the top, markup, optional <style> last. Use when creating or editing .razor files, @code blocks, or in-file <style> tags. CSS placement: tw-blazor-css-strategy. App shell: tw-blazor-layout.
+description: "Razor file authoring — one @code at the top, markup, optional <style> last. Use when creating or editing .razor files, @code blocks, or in-file <style> tags. CSS placement: tw-blazor-css-strategy. App shell: tw-blazor-layout."
 ---
 
 # `.razor` file order

--- a/skills/tw-feature-placement/SKILL.md
+++ b/skills/tw-feature-placement/SKILL.md
@@ -1,24 +1,7 @@
 ---
 name: tw-feature-placement
-description: >-
-  **TIMEWARP SKILL** — feature-cohesive folder placement, per-use-case folders, and the
-  filename grammar `<name>[-<function>]-<layer>.cs` for product code under `<family>/features/`
-  and platform clusters under `<family>/platform/` (family-generic: web, api, grpc all share this
-  machinery — worked examples below use web): which layer a file belongs to, what to name it
-  and which folder it goes in, the registry that backs TWA0015/TWA0016, and the membership-guard
-  build errors. Invoke before creating, moving, or renaming a file under a feature slice or
-  platform cluster, or when a TWA0015/TWA0016/membership-guard error appears.
-  WHEN: "Where does this handler file go?", "What do I name this contract file?",
-  "Should this file get its own folder?", "TWA0015", "TWA0016",
-  "feature file matches no registered layer suffix", "platform/postgres",
-  "add a function segment to the registry", "split a module into its own assembly".
-when-to-use: >
-  feature filename grammar, feature-cohesive folder, web/features, web/platform, api/features,
-  grpc/features, platform cluster, filename grammar, use-case folder, per-use-case folder,
-  commands folder, queries folder, TWA0015, TWA0016, feature-filename-grammar.json,
-  membership guard, feature-membership.targets, escape hatch filename, function segment,
-  layer suffix, registry edit rebuild, per-module assembly split, shared tree vs artifact folder,
-  deletion litmus test, where does this file go, seam interface placement
+description: "**TIMEWARP SKILL** — feature-cohesive folder placement, per-use-case folders, and the filename grammar `<name>[-<function>]-<layer>.cs` for product code under `<family>/features/` and platform clusters under `<family>/platform/` (family-generic: web, api, grpc all share this machinery — worked examples below use web): which layer a file belongs to, what to name it and which folder it goes in, the registry that backs TWA0015/TWA0016, and the membership-guard build errors. Invoke before creating, moving, or renaming a file under a feature slice or platform cluster, or when a TWA0015/TWA0016/membership-guard error appears. WHEN: Where does this handler file go?, What do I name this contract file?, Should this file get its own folder?, TWA0015, TWA0016, feature file matches no registered layer suffix, platform/postgres, add a function segment to the registry, split a module into its own assembly."
+when-to-use: feature filename grammar, feature-cohesive folder, web/features, web/platform, api/features, grpc/features, platform cluster, filename grammar, use-case folder, per-use-case folder, commands folder, queries folder, TWA0015, TWA0016, feature-filename-grammar.json, membership guard, feature-membership.targets, escape hatch filename, function segment, layer suffix, registry edit rebuild, per-module assembly split, shared tree vs artifact folder, deletion litmus test, where does this file go, seam interface placement
 ---
 
 # Feature placement and filename grammar

--- a/skills/tw-mock-response-factory/SKILL.md
+++ b/skills/tw-mock-response-factory/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: tw-mock-response-factory
-description: >
-  Add GetMockResponseFactory to API contracts and register factories in the SPA mock API service.
-when-to-use: >
-  GetMockResponseFactory, MockResponseFactory, MockCopicApiService, MockWebApiService,
-  MockFactories, mock mode, IMockResponseFactory, SPA development without backend
+description: Add GetMockResponseFactory to API contracts and register factories in the SPA mock API service.
+when-to-use: GetMockResponseFactory, MockResponseFactory, MockCopicApiService, MockWebApiService, MockFactories, mock mode, IMockResponseFactory, SPA development without backend
 ---
 
 # Mock Response Factory

--- a/skills/tw-slice-isolation/SKILL.md
+++ b/skills/tw-slice-isolation/SKILL.md
@@ -1,16 +1,7 @@
 ---
 name: tw-slice-isolation
-description: >-
-  **TIMEWARP SKILL** — product slice placement and TWA0009 isolation (SliceRoot,
-  namespaces, platform Applications, Components/contracts sharing,
-  CrossSliceReference opt-out). Invoke before scaffolding a new feature/slice/page
-  or when fixing TWA0009 / cross-slice references.
-  WHEN: "Add a new clients feature page", "Where does this state live?",
-  "TWA0009 slice references another product slice", "CrossSliceReference",
-  "new product area under features/", greenfield slice scaffolding.
-when-to-use: >
-  slice, slice isolation, TWA0009, CrossSliceReference, SliceRoot, TimeWarpSliceRoot,
-  product feature folder, features/, Applications platform, cross-slice, where page/state live
+description: "**TIMEWARP SKILL** — product slice placement and TWA0009 isolation (SliceRoot, namespaces, platform Applications, Components/contracts sharing, CrossSliceReference opt-out). Invoke before scaffolding a new feature/slice/page or when fixing TWA0009 / cross-slice references. WHEN: Add a new clients feature page, Where does this state live?, TWA0009 slice references another product slice, CrossSliceReference, new product area under features/, greenfield slice scaffolding."
+when-to-use: slice, slice isolation, TWA0009, CrossSliceReference, SliceRoot, TimeWarpSliceRoot, product feature folder, features/, Applications platform, cross-slice, where page/state live
 ---
 
 # Slice isolation (TWA0009)

--- a/skills/tw-web-api-contracts/SKILL.md
+++ b/skills/tw-web-api-contracts/SKILL.md
@@ -1,14 +1,7 @@
 ---
 name: tw-web-api-contracts
-description: >-
-  **TIMEWARP SKILL** — endpoint-centric Web.Contracts API contracts (Command, Query, ApiRoute,
-  I*Details, Validator, serialization tests). Invoke before scaffolding or fixing contracts.
-  WHEN: "Add a CreateTodoItem command contract", "Scaffold a GetRole query with ApiRoute and
-  IRoleDetails for the edit form", "Add a serialization round-trip test for my Command".
-when-to-use: >
-  Web.Contracts, web-contracts, command contract, query contract, ApiRoute, ApiEndpoint,
-  EndpointAuthorize, EndpointAllowAnonymous, I*Details, EditForm binding, Validator,
-  serialization round-trip, BFF, AuthApiRequest, FastEndpoint generation
+description: "**TIMEWARP SKILL** — endpoint-centric Web.Contracts API contracts (Command, Query, ApiRoute, I*Details, Validator, serialization tests). Invoke before scaffolding or fixing contracts. WHEN: Add a CreateTodoItem command contract, Scaffold a GetRole query with ApiRoute and IRoleDetails for the edit form, Add a serialization round-trip test for my Command."
+when-to-use: Web.Contracts, web-contracts, command contract, query contract, ApiRoute, ApiEndpoint, EndpointAuthorize, EndpointAllowAnonymous, I*Details, EditForm binding, Validator, serialization round-trip, BFF, AuthApiRequest, FastEndpoint generation
 ---
 
 # Web API Contracts


### PR DESCRIPTION
## Summary
- Flatten `description` / `when-to-use` on the six skills whose catalog entries published as raw `>-` / `>`.
- The live timewarp.software generator still takes the first line after `description:`. Task 193.

## Test plan
- [x] `rg -n '^description: *>' skills --glob 'SKILL.md'` — no matches
- [x] `ganda repo audit` 24/0
- [ ] After merge + site rebuild: https://timewarp.software/skills/index.json descriptions are sentences, not `>-`