### PR TITLE
Add git-owned Cursor Cloud Agent environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,20 @@
+# Cursor Cloud Agent image for timewarp-architecture (and reusable TimeWarp app shape).
+# Toolchain only: Ubuntu 24.04, .NET 10, git, sudo, Docker-in-Docker, Aspire CLI.
+# Do not COPY the repository — Cursor checks out the requested revision after the image is built.
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    DOTNET_ROOT=/usr/share/dotnet \
+    DOTNET_NOLOGO=1 \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
+    PATH="/usr/share/dotnet:/usr/local/share/dotnet-tools:${PATH}"
+
+COPY bootstrap-toolchain.sh /tmp/bootstrap-toolchain.sh
+RUN chmod +x /tmp/bootstrap-toolchain.sh \
+    && /tmp/bootstrap-toolchain.sh \
+    && rm -f /tmp/bootstrap-toolchain.sh \
+    && rm -rf /var/lib/apt/lists/*
+
+USER ubuntu
+WORKDIR /workspace

--- a/.cursor/bootstrap-toolchain.sh
+++ b/.cursor/bootstrap-toolchain.sh
@@ -17,9 +17,11 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 DOTNET_ROOT="${DOTNET_ROOT:-/usr/share/dotnet}"
 ASPIRE_TOOL_PATH="${ASPIRE_TOOL_PATH:-/usr/local/share/dotnet-tools}"
 
+APT_DPKG_OPTS=(-o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold)
+
 install_base_packages() {
   apt-get update
-  apt-get install -y --no-install-recommends \
+  apt-get "${APT_DPKG_OPTS[@]}" install -y --no-install-recommends \
     ca-certificates \
     curl \
     git \
@@ -77,7 +79,7 @@ install_docker() {
     > /etc/apt/sources.list.d/docker.list
 
   apt-get update
-  apt-get install -y --no-install-recommends \
+  apt-get "${APT_DPKG_OPTS[@]}" install -y --no-install-recommends \
     docker-ce \
     docker-ce-cli \
     containerd.io \
@@ -117,6 +119,7 @@ install_aspire_cli() {
   else
     "${DOTNET_ROOT}/dotnet" tool install Aspire.Cli --tool-path "${ASPIRE_TOOL_PATH}"
   fi
+  chmod -R a+rX "${ASPIRE_TOOL_PATH}"
   ln -sfn "${ASPIRE_TOOL_PATH}/aspire" /usr/local/bin/aspire
 }
 

--- a/.cursor/bootstrap-toolchain.sh
+++ b/.cursor/bootstrap-toolchain.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Idempotent host toolchain for Cursor Cloud Agents and the .cursor/Dockerfile.
+# Installs Ubuntu packages + .NET 10 (global.json channel) + Docker CE (DinD) + Aspire CLI.
+# Safe to re-run. Does not start dockerd and does not copy application source.
+set -euo pipefail
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "bootstrap-toolchain.sh must run as root (sudo bash .cursor/bootstrap-toolchain.sh)" >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+export DOTNET_NOLOGO=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+DOTNET_ROOT="${DOTNET_ROOT:-/usr/share/dotnet}"
+ASPIRE_TOOL_PATH="${ASPIRE_TOOL_PATH:-/usr/local/share/dotnet-tools}"
+
+install_base_packages() {
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    sudo \
+    fuse-overlayfs \
+    iptables
+}
+
+install_dotnet() {
+  if command -v dotnet >/dev/null 2>&1; then
+    local version
+    version="$(dotnet --version 2>/dev/null || true)"
+    case "${version}" in
+      10.*)
+        echo "dotnet ${version} already present"
+        return 0
+        ;;
+    esac
+  fi
+
+  curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+  bash /tmp/dotnet-install.sh --channel 10.0 --install-dir "${DOTNET_ROOT}"
+  rm -f /tmp/dotnet-install.sh
+  ln -sfn "${DOTNET_ROOT}/dotnet" /usr/local/bin/dotnet
+}
+
+write_dotnet_path() {
+  mkdir -p /etc/profile.d
+  cat > /etc/profile.d/dotnet.sh <<EOF
+export DOTNET_ROOT=${DOTNET_ROOT}
+export PATH="${DOTNET_ROOT}:${ASPIRE_TOOL_PATH}:\$PATH"
+export DOTNET_NOLOGO=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+EOF
+  chmod 644 /etc/profile.d/dotnet.sh
+
+  if [ -f /etc/environment ]; then
+    grep -q '^DOTNET_ROOT=' /etc/environment || echo "DOTNET_ROOT=${DOTNET_ROOT}" >> /etc/environment
+  fi
+}
+
+install_docker() {
+  install -m 0755 -d /etc/apt/keyrings
+  if [ ! -f /etc/apt/keyrings/docker.gpg ]; then
+    curl --retry 3 --retry-delay 5 -fsSL https://download.docker.com/linux/ubuntu/gpg \
+      | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+    chmod a+r /etc/apt/keyrings/docker.gpg
+  fi
+
+  local codename
+  codename="$(. /etc/os-release && echo "${VERSION_CODENAME}")"
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${codename} stable" \
+    > /etc/apt/sources.list.d/docker.list
+
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    docker-ce \
+    docker-ce-cli \
+    containerd.io \
+    docker-buildx-plugin \
+    docker-compose-plugin
+
+  mkdir -p /etc/docker
+  cat > /etc/docker/daemon.json <<'EOF'
+{
+  "storage-driver": "fuse-overlayfs"
+}
+EOF
+
+  if [ -x /usr/sbin/iptables-legacy ]; then
+    update-alternatives --set iptables /usr/sbin/iptables-legacy || true
+  fi
+  if [ -x /usr/sbin/ip6tables-legacy ]; then
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy || true
+  fi
+}
+
+configure_ubuntu_user() {
+  id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash ubuntu
+  groupadd -f docker
+  usermod -aG docker ubuntu
+  usermod -aG sudo ubuntu
+  echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/ubuntu
+  chmod 440 /etc/sudoers.d/ubuntu
+}
+
+install_aspire_cli() {
+  export DOTNET_ROOT
+  export PATH="${DOTNET_ROOT}:${PATH}"
+  mkdir -p "${ASPIRE_TOOL_PATH}"
+  if [ -x "${ASPIRE_TOOL_PATH}/aspire" ]; then
+    echo "Aspire CLI already present at ${ASPIRE_TOOL_PATH}/aspire"
+  else
+    "${DOTNET_ROOT}/dotnet" tool install Aspire.Cli --tool-path "${ASPIRE_TOOL_PATH}"
+  fi
+  ln -sfn "${ASPIRE_TOOL_PATH}/aspire" /usr/local/bin/aspire
+}
+
+install_base_packages
+install_dotnet
+write_dotnet_path
+install_docker
+configure_ubuntu_user
+install_aspire_cli
+
+echo "Toolchain ready:"
+"${DOTNET_ROOT}/dotnet" --info | sed -n '1,20p'
+docker --version
+aspire --version || "${ASPIRE_TOOL_PATH}/aspire" --version
+git --version

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,9 @@
+{
+  "name": "TimeWarp Architecture",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "user": "ubuntu",
+  "install": "bash .cursor/install.sh",
+  "start": "bash .cursor/start.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent install: repo-derived restore after checkout.
+# Do not start Docker, Aspire, or any other long-running process here.
+set -euo pipefail
+
+export DOTNET_NOLOGO=1
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "dotnet is missing. The Cloud Agent image (.cursor/Dockerfile) must supply .NET 10." >&2
+  exit 1
+fi
+
+echo "dotnet $(dotnet --version)"
+dotnet restore timewarp-architecture.slnx
+dotnet tool restore
+dotnet run tools/dev-cli/dev.cs -- self-install
+dotnet dev-certs https --trust || true
+
+if command -v aspire >/dev/null 2>&1; then
+  echo "aspire $(aspire --version 2>/dev/null || true)"
+fi
+
+echo "Cloud Agent install complete."

--- a/.cursor/readme.md
+++ b/.cursor/readme.md
@@ -1,0 +1,57 @@
+# Cursor Cloud Agent environment
+
+Git-owned Cloud Agent environment for `timewarp-architecture`. Future TimeWarp
+app repos can reuse this shape.
+
+## What is in git
+
+| File | Role |
+|------|------|
+| `environment.json` | Cursor Cloud config. `dockerfile` / `context` are relative to `.cursor`. |
+| `Dockerfile` | Ubuntu 24.04 + .NET 10 + git + sudo + Docker-in-Docker + Aspire CLI. |
+| `bootstrap-toolchain.sh` | Idempotent toolchain installer used by the Dockerfile and first-run VMs. |
+| `install.sh` | After checkout: restore the solution, restore local tools, self-install `bin/dev`. |
+| `start.sh` | Per-boot: start `dockerd` so Aspire can run containers. |
+
+The image does **not** `COPY` application source. Cursor checks out the requested
+revision, then runs `install`.
+
+## How to reuse on another TimeWarp repo
+
+1. Copy this `.cursor/` directory into the other repo.
+2. Keep `Dockerfile` / `bootstrap-toolchain.sh` unless that repo needs a different
+   OS or SDK channel. SDK channel must stay aligned with that repo's `global.json`.
+3. Edit `install.sh` to match that repo's bootstrap (`dotnet restore <sln/slnx>`,
+   `dotnet run tools/dev-cli/dev.cs -- self-install` when a `dev` CLI exists).
+4. Keep `start.sh` if the repo uses Aspire, Testcontainers, or any Docker-backed
+   host. Drop it only when the repo never starts containers.
+5. Commit `.cursor/` and open a PR. Agents that start on that revision pick up
+   `.cursor/environment.json` first (ahead of personal or team dashboard envs).
+
+Do not copy the Amina AOA image. That image adds extra agent CLIs, an `amina`
+user, `docker.sock` GID mapping, and a `sleep infinity` entrypoint — wrong for
+Cursor Cloud.
+
+## What stays dashboard-only
+
+- Secrets and environment-scoped credentials (NuGet tokens, cloud keys, test logins)
+- Network allowlists / egress policy
+- Saved snapshots and Builds created from the dashboard
+- Team vs personal environment assignment
+
+A dashboard snapshot is a convenience disk image. It is not a substitute for
+committing `.cursor/` when other repos or branches need the same toolchain.
+
+## Commands this environment is built for
+
+From the repo root, same pipeline as `AGENTS.md`:
+
+```bash
+dotnet run tools/dev-cli/dev.cs -- build   # or ./bin/dev build after self-install
+dotnet run tools/dev-cli/dev.cs -- test    # needs Docker for some host suites
+dotnet run tools/dev-cli/dev.cs -- run     # Aspire AppHost; needs Docker
+```
+
+`dev build` compiles `timewarp-architecture.slnx` (warnings are errors). The
+AppHost SDK comes from NuGet (`Aspire.AppHost.Sdk`); Docker is required to
+*run* Aspire resources, not to compile them.

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -2,9 +2,21 @@
 # Per-boot Docker daemon for Aspire / container tests. Must return after readiness.
 set -euo pipefail
 
-if docker info >/dev/null 2>&1; then
+docker_ready() {
+  docker info >/dev/null 2>&1 || sudo docker info >/dev/null 2>&1
+}
+
+print_docker_version() {
+  if docker info >/dev/null 2>&1; then
+    docker version --format '{{.Server.Version}}'
+  else
+    sudo docker version --format '{{.Server.Version}}'
+  fi
+}
+
+if docker_ready; then
   echo "Docker daemon already running."
-  docker version --format '{{.Server.Version}}'
+  print_docker_version
   exit 0
 fi
 
@@ -12,14 +24,14 @@ if command -v service >/dev/null 2>&1; then
   sudo service docker start || true
 fi
 
-if ! docker info >/dev/null 2>&1; then
+if ! docker_ready; then
   sudo dockerd --host=unix:///var/run/docker.sock >/tmp/dockerd.log 2>&1 &
 fi
 
 for _ in $(seq 1 40); do
-  if docker info >/dev/null 2>&1; then
+  if docker_ready; then
     echo "Docker daemon is ready."
-    docker version --format '{{.Server.Version}}'
+    print_docker_version
     exit 0
   fi
   sleep 1

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Per-boot Docker daemon for Aspire / container tests. Must return after readiness.
+# Idempotent: already-running dockerd succeeds; a stale leftover daemon is restarted.
 set -euo pipefail
 
 docker_ready() {
@@ -14,23 +15,48 @@ print_docker_version() {
   fi
 }
 
+stop_stale_docker() {
+  sudo service docker stop || true
+  sudo pkill -x dockerd >/dev/null 2>&1 || true
+  sudo pkill -x containerd >/dev/null 2>&1 || true
+  sleep 1
+}
+
 if docker_ready; then
   echo "Docker daemon already running."
   print_docker_version
   exit 0
 fi
 
+if pgrep -x dockerd >/dev/null 2>&1; then
+  echo "Stale dockerd detected; restarting."
+  stop_stale_docker
+fi
+
 if command -v service >/dev/null 2>&1; then
   sudo service docker start || true
 fi
 
-if ! docker_ready; then
+if ! docker_ready && command -v dockerd >/dev/null 2>&1; then
   sudo dockerd --host=unix:///var/run/docker.sock >/tmp/dockerd.log 2>&1 &
 fi
 
 for _ in $(seq 1 40); do
   if docker_ready; then
     echo "Docker daemon is ready."
+    print_docker_version
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Docker still not ready; forcing a service restart."
+stop_stale_docker
+sudo service docker start || true
+
+for _ in $(seq 1 20); do
+  if docker_ready; then
+    echo "Docker daemon is ready after restart."
     print_docker_version
     exit 0
   fi

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Per-boot Docker daemon for Aspire / container tests. Must return after readiness.
+set -euo pipefail
+
+if docker info >/dev/null 2>&1; then
+  echo "Docker daemon already running."
+  docker version --format '{{.Server.Version}}'
+  exit 0
+fi
+
+if command -v service >/dev/null 2>&1; then
+  sudo service docker start || true
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  sudo dockerd --host=unix:///var/run/docker.sock >/tmp/dockerd.log 2>&1 &
+fi
+
+for _ in $(seq 1 40); do
+  if docker info >/dev/null 2>&1; then
+    echo "Docker daemon is ready."
+    docker version --format '{{.Server.Version}}'
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Docker daemon failed to become ready." >&2
+if [ -f /tmp/dockerd.log ]; then
+  tail -n 50 /tmp/dockerd.log >&2 || true
+fi
+exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -354,3 +354,19 @@ Do not create perpetual/never-closing tasks. See the `tw-kanban` skill.
 `documentation/` (developer + conceptual guides, ADRs) — in-repo markdown is the documentation
 of record; generated apps receive the tree in their template output. No published docs site
 (re-evaluate a public presence when the repo gains an outward-facing audience).
+
+## Cursor Cloud specific instructions
+
+This repo ships a git-owned Cloud Agent environment under `.cursor/` (see
+`.cursor/readme.md` for reuse on other TimeWarp repos).
+
+- Image toolchain: Ubuntu 24.04, .NET 10 matching `global.json`, git, sudo,
+  Docker-in-Docker (`fuse-overlayfs` / `iptables-legacy`), Aspire CLI.
+- `install` restores the solution and self-installs `bin/dev`. It must terminate.
+  Do not start `dev run` or `dockerd` from `install`.
+- `start` brings up the Docker daemon so Aspire / container-backed tests can run.
+- Build and test with this repo's pipeline: `dev build` (or
+  `dotnet run tools/dev-cli/dev.cs -- build`). Warnings are errors; 0/0 is the
+  only acceptable compile result.
+- Secrets, egress allowlists, and dashboard snapshots stay in the Cursor
+  dashboard. They are not a substitute for committing `.cursor/`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This repo had no `.cursor/` folder. Cloud Agents were landing on a stock Ubuntu VM (git + sudo only) and any working toolchain lived only as a dashboard snapshot.

This PR commits a reusable environment so future TimeWarp Cloud Agents — and other TimeWarp app repos — start from the same shape this template actually needs.

## What shipped

- `.cursor/environment.json` — repo-managed Cloud config (`dockerfile` is relative to `.cursor`; no project `COPY`)
- `.cursor/Dockerfile` — Ubuntu 24.04 image that runs the bootstrap script
- `.cursor/bootstrap-toolchain.sh` — idempotent install of .NET 10 (`global.json` channel 10.0 / `rollForward: latestFeature`), git, sudo, Docker CE with Cursor's DinD recipe (`fuse-overlayfs` + `iptables-legacy`), and the Aspire CLI (`dotnet tool install Aspire.Cli`)
- `.cursor/install.sh` — after checkout: `dotnet restore timewarp-architecture.slnx`, `dotnet tool restore`, `dev` self-install, HTTPS dev cert trust
- `.cursor/start.sh` — per-boot `dockerd` so Aspire can start containers (restarts a stale leftover daemon)
- `AGENTS.md` — Cursor Cloud pointer (secrets stay dashboard-only)

The image does **not** copy Amina AOA extras (extra agent CLIs, `amina` user, `docker.sock` GID mapping, `sleep infinity` entrypoint).

## How to reuse on other TimeWarp repos

Copy `.cursor/` into the other repo, then:

1. Keep the Dockerfile / bootstrap unless that repo's `global.json` pins a different SDK channel.
2. Edit `install.sh` to that repo's restore / `dev` CLI bootstrap.
3. Keep `start.sh` if Aspire, Testcontainers, or any Docker-backed host is in play.
4. Commit `.cursor/` on a branch. Agents that start on that revision use `.cursor/environment.json` first, ahead of personal or team dashboard environments.

See `.cursor/readme.md`.

## What is still dashboard-only

- Secrets and environment-scoped credentials (NuGet tokens, cloud keys, test logins)
- Network allowlists / egress policy
- Saved snapshots and Builds created in the Cursor dashboard
- Team vs personal environment assignment

A dashboard snapshot is a convenience disk image. It is not a substitute for committing `.cursor/`.

After merge to `master`, Cursor can create a **promotable** environment Build from the default branch. A draft Build from this feature branch can be tested but cannot be promoted.

## Build attempt (this Cloud Agent)

This agent started on stock Ubuntu 24.04.4 with **no .NET, no Docker, no Aspire, no `ganda`**.

### Commands

```bash
sudo bash .cursor/bootstrap-toolchain.sh   # twice; second run was a no-op
bash .cursor/install.sh                    # twice; second restore was up-to-date
bash .cursor/start.sh
sudo docker run --rm hello-world
./bin/dev build                            # this repo's real pipeline
```

Equivalent compile command: `dotnet run tools/dev-cli/dev.cs -- build` → `dotnet build timewarp-architecture.slnx -c Release`.

### Results

| Check | Result |
| --- | --- |
| First-run VM | Ubuntu 24.04.4, git 2.43.0, passwordless sudo; **no dotnet / docker / aspire** |
| `.NET` after bootstrap | **10.0.400** (matches `global.json`) |
| Docker after bootstrap + `start.sh` | **29.7.2**, storage-driver **fuse-overlayfs**; `hello-world` succeeded |
| Aspire CLI | **13.5.3** (`Aspire.Cli` global tool; AppHost SDK in-repo is 13.5.2) |
| `install.sh` idempotence | Passed twice |
| `./bin/dev build` | **Passed — 0 Warning(s), 0 Error(s)** including `aspire-app-host` |
| Draft env build `install` | Exit 0 on [bld-20260827-769e4bb5-f910-4392-a049-26e021ba810a](https://cursor.com/dashboard/cloud-agents/builds/bld-20260827-769e4bb5-f910-4392-a049-26e021ba810a) |
| Fresh Cloud Agent from that build | `./bin/dev build` **0/0** again; first `start.sh` hit a leftover `dockerd` (fixed in this PR) |

### Hypothesis vs what actually blocked first

The hypothesis was "first failure will be missing Docker for Aspire." For **`dev build` that was wrong**.

1. **First real blocker on the stock VM:** missing .NET SDK. `dev build` cannot start without `dotnet`.
2. **`dev build` does not need Docker.** The AppHost compiles via `Aspire.AppHost.Sdk` from NuGet. Docker is required to *run* Aspire (`dev run`, postgres, container-backed tests), not to compile.
3. **Docker-in-Docker works** once `start.sh` brings up `dockerd` with Cursor's `fuse-overlayfs` / `iptables-legacy` recipe. `sudo docker run --rm hello-world` succeeded.

Non-blocking notes (not compile failures):

- First restore printed `An issue was encountered verifying workloads` (no wasm-tools workload set). WASM SPA still compiled.
- `dotnet dev-certs https --trust` exits with a Linux OpenSSL trust warning (same as CI's `|| true`). Tests that use HTTPS need `SSL_CERT_DIR="$HOME/.aspnet/dev-certs/trust:/usr/lib/ssl/certs:/etc/ssl/certs"` — already documented in this repo's workflow.
- `ganda` is a private TimeWarp GitHub package and is not part of this environment. Kanban create was skipped rather than hand-numbering a card.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b60ea9f2-108a-4a67-88e0-ce5add3b1190?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b60ea9f2-108a-4a67-88e0-ce5add3b1190&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

